### PR TITLE
feat: add PHP 8.4 packages

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1719994518,
-        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
         "type": "github"
       },
       "original": {
@@ -19,11 +19,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1722141560,
-        "narHash": "sha256-Ul3rIdesWaiW56PS/Ak3UlJdkwBrD4UcagCmXZR9Z7Y=",
+        "lastModified": 1734435836,
+        "narHash": "sha256-kMBQ5PRiFLagltK0sH+08aiNt3zGERC2297iB6vrvlU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "038fb464fcfa79b4f08131b07f2d8c9a6bcc4160",
+        "rev": "4989a246d7a390a859852baddb1013f825435cee",
         "type": "github"
       },
       "original": {
@@ -35,24 +35,24 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1719876945,
-        "narHash": "sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI=",
+        "lastModified": 1733096140,
+        "narHash": "sha256-1qRH7uAUsyQI7R1Uwl4T+XvdNv778H0Nb5njNrqvylY=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
       }
     },
     "php-src-81": {
       "flake": false,
       "locked": {
-        "lastModified": 1717566497,
-        "narHash": "sha256-LvgGu6AzaIsWtZpYm//IZoPM/upyI5FNZ7KXS2kkZkM=",
+        "lastModified": 1733823300,
+        "narHash": "sha256-a7L+LYUSkoCV7Yfjs1xSi4z82HThrU7NOM93aBecdXY=",
         "owner": "php",
         "repo": "php-src",
-        "rev": "a87ccc7ca2644e327c210e68b4d98df98ad33523",
+        "rev": "8a9d45b86f89bbaffa6e3f30eb8b75b39c509a1d",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
     "php-src-82": {
       "flake": false,
       "locked": {
-        "lastModified": 1722362482,
-        "narHash": "sha256-gyYiEoInGhZBvAmqxp+Uhc5bYhAESkRzgjPWUHm76so=",
+        "lastModified": 1734716734,
+        "narHash": "sha256-Yierauc2aCS//j0YOWFoCbTgUzf6AtwczBVfl7sPDLs=",
         "owner": "php",
         "repo": "php-src",
-        "rev": "b282dd749f8b4133724160e3751e2edda03593ae",
+        "rev": "6f579934f0d4391af0eab961d612929b71320b39",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     "php-src-83": {
       "flake": false,
       "locked": {
-        "lastModified": 1722362610,
-        "narHash": "sha256-Sdzf9sSDwJIl5WB1mFDTOXVvItQAN5ymjCtSS0hj1dM=",
+        "lastModified": 1734881221,
+        "narHash": "sha256-INxa9HRcV2TprGBkPypskITuEbcLygj6MWuUjHPYcqs=",
         "owner": "php",
         "repo": "php-src",
-        "rev": "4049594adfa60e4d7ebda08a3ac4a4ecb8f35dc2",
+        "rev": "fcbfd5a6800cc46158daa4a4ed5ae1c112002421",
         "type": "github"
       },
       "original": {
@@ -96,14 +96,31 @@
         "type": "github"
       }
     },
+    "php-src-84": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1734881404,
+        "narHash": "sha256-59Hwl0WrFYrUuGutsyaEhN7/DQJObf+em0Mp6p10k9E=",
+        "owner": "php",
+        "repo": "php-src",
+        "rev": "0285e9a8685a40e85ba56256eb3793d6895a6f17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "php",
+        "ref": "PHP-8.4",
+        "repo": "php-src",
+        "type": "github"
+      }
+    },
     "php-src-master": {
       "flake": false,
       "locked": {
-        "lastModified": 1722373512,
-        "narHash": "sha256-UNMtWJTs37co2o8FyD+SHTm9UROzXfh45Pk+sRmtrwg=",
+        "lastModified": 1734911664,
+        "narHash": "sha256-enKnXwwE6yuzSr6uGIuYNTpHbAVWDhKDpOQvenlFHEo=",
         "owner": "php",
         "repo": "php-src",
-        "rev": "3c68661ec993f349cb7539330a7191258870ff4b",
+        "rev": "bf5e6c5f2d812051f8d69893384c67492724e54c",
         "type": "github"
       },
       "original": {
@@ -120,6 +137,7 @@
         "php-src-81": "php-src-81",
         "php-src-82": "php-src-82",
         "php-src-83": "php-src-83",
+        "php-src-84": "php-src-84",
         "php-src-master": "php-src-master",
         "systems": "systems"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,10 @@
       url = "github:php/php-src/PHP-8.3";
       flake = false;
     };
+    php-src-84 = {
+      url = "github:php/php-src/PHP-8.4";
+      flake = false;
+    };
   };
 
   outputs =

--- a/src/makePhpPackage.nix
+++ b/src/makePhpPackage.nix
@@ -82,7 +82,7 @@ let
 
             dom = prevPO.extensions.dom.overrideAttrs (attrs: {
               NIX_CFLAGS_COMPILE = attrs.NIX_CFLAGS_COMPILE or "" + cflags;
-              patches = (patches.dom or [ ]) ++ attrs.patches;
+              patches = (patches.dom or [ ]) ++ (attrs.patches or []);
             });
 
             opcache = prevPO.extensions.opcache.overrideAttrs (attrs: {
@@ -144,12 +144,12 @@ let
 
             tokenizer = prevPO.extensions.tokenizer.overrideAttrs (attrs: {
               NIX_CFLAGS_COMPILE = attrs.NIX_CFLAGS_COMPILE or "" + cflags;
-              patches = [ ] ++ lib.optionals (lib.versionAtLeast prevPO.php.version "8.1") attrs.patches;
+              patches = [ ] ++ lib.optionals (lib.versionAtLeast prevPO.php.version "8.1") (attrs.patches or []);
             });
 
             sqlite3 = prevPO.extensions.sqlite3.overrideAttrs (attrs: {
               NIX_CFLAGS_COMPILE = attrs.NIX_CFLAGS_COMPILE or "" + cflags;
-              patches = (patches.sqlite3 or [ ]) ++ attrs.patches;
+              patches = (patches.sqlite3 or [ ]) ++ (attrs.patches or []);
             });
           };
         };

--- a/src/makePhpPackage.nix
+++ b/src/makePhpPackage.nix
@@ -120,6 +120,9 @@ let
             # the SOAP extension requires the `session` extension.
             soap = prevPO.extensions.soap.overrideAttrs (attrs: {
               internalDeps = attrs.internalDeps or [ ] ++ [ prevPO.extensions.session ];
+              # Remove soap patch as it has been upstreamed
+              # See https://github.com/NixOS/nixpkgs/pull/358196 (fix soap test)
+              patches = if (lib.versionAtLeast prevPO.php.version "8.3") then [] else (attrs.patches or []);
             });
 
             sockets = prevPO.extensions.sockets.overrideAttrs (attrs: {

--- a/src/overlays/active.nix
+++ b/src/overlays/active.nix
@@ -52,6 +52,11 @@ let
       hash = "sha256-AcIM3hxaVpZlGHXtIvUHhJZ5+6dA+MQhYWt9Q9f3l9o=";
       extensions = extensions.php81-to-php8300;
     }
+    {
+      version = "8.4.2";
+      hash = "sha256-70/pkhuIXOOwR3kqtgJg6vZX4igSvlEdGdDkXt+YR4M=";
+      extensions = extensions.php-from-8400;
+    }
   ];
 in
 lib.mapAttrs (k: v: ((makePhpPackage v).withExtensions (v.extensions))) (makePackageSet versions)

--- a/src/overlays/active.nix
+++ b/src/overlays/active.nix
@@ -34,22 +34,18 @@ let
 
   versions = [
     {
-      version = "8.1.28";
-      hash = "sha256-i+RQCW4BU8R9dThOfdWVzIl/HVPOAGBwjOlYm8wxQe4=";
-      patches = {
-        php = [ patches.libxmlpatch ];
-      };
-      cflags = " -Wno-compare-distinct-pointer-types -Wno-implicit-const-int-float-conversion -Wno-deprecated-declarations -Wno-incompatible-function-pointer-types -Wno-incompatible-pointer-types-discards-qualifiers";
+      version = "8.1.31";
+      hash = "sha256-CzmCizRRUcrxt5XZ9LkjyYhyMXdsMwdt/J2QpEOQ0Nw=";
       extensions = extensions.php81-to-php8300;
     }
     {
-      version = "8.2.19";
-      hash = "sha256-PBj3zlG3x7JreX4flwedOGswNH6wToF/XmyOmydeKmo=";
+      version = "8.2.27";
+      hash = "sha256-blfbr3aafz3rTw9IuMU15nHMChgCLtf2/yO1DpQdS2A=";
       extensions = extensions.php81-to-php8300;
     }
     {
-      version = "8.3.7";
-      hash = "sha256-AcIM3hxaVpZlGHXtIvUHhJZ5+6dA+MQhYWt9Q9f3l9o=";
+      version = "8.3.15";
+      hash = "sha256-sWdaT/cwtYEbjmp2h0iMQug14Vapl3aqPm8Ber2jvpg=";
       extensions = extensions.php81-to-php8300;
     }
     {

--- a/src/overlays/archive.nix
+++ b/src/overlays/archive.nix
@@ -167,6 +167,15 @@ let
       cflags = " -Wno-compare-distinct-pointer-types -Wno-implicit-const-int-float-conversion -Wno-deprecated-declarations -Wno-incompatible-function-pointer-types -Wno-incompatible-pointer-types-discards-qualifiers";
       extensions = extensions.php81-to-php8300;
     }
+    {
+      version = "8.1.28";
+      hash = "sha256-i+RQCW4BU8R9dThOfdWVzIl/HVPOAGBwjOlYm8wxQe4=";
+      patches = {
+        php = [ patches.libxmlpatch patches.ext_dom_tests ];
+      };
+      cflags = " -Wno-compare-distinct-pointer-types -Wno-implicit-const-int-float-conversion -Wno-deprecated-declarations -Wno-incompatible-function-pointer-types -Wno-incompatible-pointer-types-discards-qualifiers";
+      extensions = extensions.php81-to-php8300;
+    }
 
     {
       version = "8.2.5";
@@ -315,6 +324,11 @@ let
       hash = "sha256-GRMWwgMmfZYWC0fSL5VdTcEXk96KXzJ+DCp2J1polOo=";
       extensions = extensions.php81-to-php8300;
     }
+    {
+      version = "8.2.19";
+      hash = "sha256-PBj3zlG3x7JreX4flwedOGswNH6wToF/XmyOmydeKmo=";
+      extensions = extensions.php81-to-php8300;
+    }
 
     {
       version = "8.3.0";
@@ -351,6 +365,11 @@ let
     {
       version = "8.3.4";
       hash = "sha256-PFyvGODAokOq7JE6OeywkgQxla3eTD/ELpRdpbkndpU=";
+      extensions = extensions.php81-to-php8300;
+    }
+    {
+      version = "8.3.7";
+      hash = "sha256-AcIM3hxaVpZlGHXtIvUHhJZ5+6dA+MQhYWt9Q9f3l9o=";
       extensions = extensions.php81-to-php8300;
     }
   ];

--- a/src/overlays/snapshot.nix
+++ b/src/overlays/snapshot.nix
@@ -14,10 +14,6 @@ let
     php-8-1-snapshot = {
       version = "8.1.999-${inputs.php-src-81.shortRev}";
       src = inputs.php-src-81;
-      patches = {
-        php = [ patches.libxmlpatch ];
-      };
-      cflags = " -Wno-compare-distinct-pointer-types -Wno-implicit-const-int-float-conversion -Wno-deprecated-declarations -Wno-incompatible-function-pointer-types -Wno-incompatible-pointer-types-discards-qualifiers";
       extensions = extensions.php81-to-php8300;
     };
     php-8-2-snapshot = {

--- a/src/overlays/snapshot.nix
+++ b/src/overlays/snapshot.nix
@@ -30,8 +30,13 @@ let
       src = inputs.php-src-83;
       extensions = extensions.php81-to-php8300;
     };
+    php-8-4-snapshot = {
+      version = "8.4.999-${inputs.php-src-84.shortRev}";
+      src = inputs.php-src-84;
+      extensions = extensions.php-from-8400;
+    };
     php-master-snapshot = {
-      version = "8.4.999-${inputs.php-src-master.shortRev}";
+      version = "8.5.999-${inputs.php-src-master.shortRev}";
       src = inputs.php-src-master;
       extensions = extensions.php-from-8400;
     };


### PR DESCRIPTION
Hi @drupol,

It's been a long time since this repository has not been updated. Therefore PHP 8.4 has been released last month and I added it because I am using a lot this repository :wink:.

I only built PHP 8.4 packages on `x86_64-linux` platform.

I hope those changes match your requirements!

Regards
